### PR TITLE
feat: Indirect Expenses item to be created for all accounts under Account groups within Indirect Expense.

### DIFF
--- a/csf_tz/csf_tz/account.js
+++ b/csf_tz/csf_tz/account.js
@@ -14,35 +14,24 @@ frappe.ui.form.on("Account", {
         frm.trigger("onload_post_render");
     },
     create_expenses_item_btn: function (frm) {
-        if (!frm.doc.parent_account || !frm.doc.parent_account.includes("Indirect Expenses") || frm.doc.item){
-            frm.remove_custom_button("Create Expenses Item");
-        }
-        else{
-            frm.add_custom_button(__("Create Expenses Item"), function() {
-                frappe.call({
-                    method: 'csf_tz.custom_api.add_indirect_expense_item',
-                    args: {
-                        account_name: frm.doc.name,
-                    },
-                    callback: function(r) {
-                       if (r.message) {
-                           frm.set_value("item",r.message);
-                           frm.refresh_field("item");
-                           frm.save();
-                       }
+        frm.add_custom_button(__("Create Expenses Item"), function() {
+            frappe.call({
+                method: 'csf_tz.custom_api.add_indirect_expense_item',
+                args: {
+                    account_name: frm.doc.name,
+                },
+                callback: function(r) {
+                    if (r.message) {
+                        frm.set_value("item",r.message);
+                        frm.refresh_field("item");
+                        frm.save();
                     }
-                });
+                }
             });
-        }
+        });
     },
     parent_account: function(frm) {
         frm.trigger("create_expenses_item_btn");
-        if (!frm.doc.parent_account || !frm.doc.parent_account.includes("Indirect Expenses")){
-            frm.set_df_property("item", "hidden", true);
-        }
-        else {
-            frm.set_df_property("item", "hidden", false);
-        }
         frm.refresh_field("item");
     },
     item: function(frm) {

--- a/csf_tz/custom_api.py
+++ b/csf_tz/custom_api.py
@@ -419,9 +419,9 @@ def make_delivery_note(source_name, target_doc=None, set_warehouse=None):
 def create_indirect_expense_item(doc,method=None):
     if doc.is_new() and method == "validate":
         return
-    if not doc.parent_account or not "Indirect Expenses" in doc.parent_account or not doc.company:
+    if not doc.parent_account or doc.is_group or not check_expenses_in_parent_accounts(doc.name) or not doc.company:
         return
-    if not doc.parent_account and not "Indirect Expenses" in doc.parent_account and doc.item:
+    if not doc.parent_account and not check_expenses_in_parent_accounts(doc.account_name) and doc.item:
         doc.item = ""
         return
     indirect_expenses_group = frappe.db.exists("Item Group", "Indirect Expenses")
@@ -476,6 +476,23 @@ def create_indirect_expense_item(doc,method=None):
         doc.item = new_item.name
     doc.db_update()
     return new_item.name
+
+
+def check_expenses_in_parent_accounts(account_name):
+    parent_account_1 = frappe.get_value('Account', account_name, "parent_account")
+    if "Indirect Expenses" in str(parent_account_1):
+        return True
+    else:
+        parent_account_2 = frappe.get_value('Account', parent_account_1, "parent_account")
+        if "Indirect Expenses" in str(parent_account_2):
+            return True
+        else:
+            parent_account_3 = frappe.get_value('Account', parent_account_2, "parent_account")
+            if "Indirect Expenses" in str(parent_account_3):
+                return True
+            else:
+                return False
+    return False
 
 
 @frappe.whitelist()


### PR DESCRIPTION
- [ ]  Currently only immediate child accounts under Indirect Expense are considered for creating Expense Item.
- [ ]  Need this feature for all account codes within the group
- [ ]  Also need this for only NON-Group
- [ ]  3 levels of the parent should be Indirect Cost then the item should be created