### PR TITLE
feat: Fetch tax category based on settings in default Tax and Charges Template in relevant doctypes 

### DIFF
--- a/csf_tz/csf_tz/delivery_note.js
+++ b/csf_tz/csf_tz/delivery_note.js
@@ -92,7 +92,6 @@ frappe.ui.keys.add_shortcut({
 
 
 frappe.ui.form.on("Delivery Note", {
-	
 	refresh: function(frm, dt, dn) {
 		if ((!frm.is_return) && (frm.status!="Closed" || frm.is_new())) {
 			if (frm.doc.docstatus===0) {
@@ -122,7 +121,26 @@ frappe.ui.form.on("Delivery Note", {
 			}
 		}
 
-	},
-
-
+    },
+    customer: function(frm) {
+        console.log(frm.doc.name);
+        setTimeout(function() {
+            if (!frm.doc.tax_category){
+                frappe.call({
+                    method: "csf_tz.custom_api.get_tax_category",
+                    args: {
+                        doc_type: frm.doc.doctype,
+                        company: frm.doc.company,
+                    },
+                    callback: function(r) {
+                        console.log(r.message);
+                        if(!r.exc) {
+                            frm.set_value("tax_category", r.message);
+                            frm.trigger("tax_category");
+                        }
+                    }
+                });           
+        }
+          }, 1000);   
+    },
 });

--- a/csf_tz/csf_tz/doctype/csf_tz_settings/csf_tz_settings.json
+++ b/csf_tz/csf_tz/doctype/csf_tz_settings/csf_tz_settings.json
@@ -6,6 +6,7 @@
  "field_order": [
   "unique_records",
   "validate_net_rate",
+  "fetch_default_tax_category",
   "column_break_3",
   "auto_pos_for_role"
  ],
@@ -31,10 +32,17 @@
   {
    "fieldname": "column_break_3",
    "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "description": "Fetch Tax Category from Default Tax Templates",
+   "fieldname": "fetch_default_tax_category",
+   "fieldtype": "Check",
+   "label": "Fetch Default Tax Category"
   }
  ],
  "issingle": 1,
- "modified": "2020-07-02 16:36:27.922374",
+ "modified": "2020-07-24 22:34:38.811578",
  "modified_by": "Administrator",
  "module": "CSF TZ",
  "name": "CSF TZ Settings",

--- a/csf_tz/csf_tz/purchase_invoice.js
+++ b/csf_tz/csf_tz/purchase_invoice.js
@@ -1,0 +1,21 @@
+frappe.ui.form.on("Purchase Invoice", {
+    supplier: function(frm) {
+        setTimeout(function() {
+            if (!frm.doc.tax_category){
+                frappe.call({
+                    method: "csf_tz.custom_api.get_tax_category",
+                    args: {
+                        doc_type: frm.doc.doctype,
+                        company: frm.doc.company,
+                    },
+                    callback: function(r) {
+                        if(!r.exc) {
+                            frm.set_value("tax_category", r.message);
+                            frm.trigger("tax_category");
+                        }
+                    }
+                });           
+        }
+          }, 1000);   
+    },
+});

--- a/csf_tz/csf_tz/purchase_order.js
+++ b/csf_tz/csf_tz/purchase_order.js
@@ -1,0 +1,21 @@
+frappe.ui.form.on("Purchase Order", {
+    supplier: function(frm) {
+        setTimeout(function() {
+            if (!frm.doc.tax_category){
+                frappe.call({
+                    method: "csf_tz.custom_api.get_tax_category",
+                    args: {
+                        doc_type: frm.doc.doctype,
+                        company: frm.doc.company,
+                    },
+                    callback: function(r) {
+                        if(!r.exc) {
+                            frm.set_value("tax_category", r.message);
+                            frm.trigger("tax_category");
+                        }
+                    }
+                });           
+        }
+          }, 1000);   
+    },
+});

--- a/csf_tz/csf_tz/purchase_receipt.js
+++ b/csf_tz/csf_tz/purchase_receipt.js
@@ -1,0 +1,21 @@
+frappe.ui.form.on("Purchase Receipt", {
+    supplier: function(frm) {
+        setTimeout(function() {
+            if (!frm.doc.tax_category){
+                frappe.call({
+                    method: "csf_tz.custom_api.get_tax_category",
+                    args: {
+                        doc_type: frm.doc.doctype,
+                        company: frm.doc.company,
+                    },
+                    callback: function(r) {
+                        if(!r.exc) {
+                            frm.set_value("tax_category", r.message);
+                            frm.trigger("tax_category");
+                        }
+                    }
+                });           
+        }
+          }, 1000);   
+    },
+});

--- a/csf_tz/csf_tz/quotation.js
+++ b/csf_tz/csf_tz/quotation.js
@@ -1,0 +1,21 @@
+frappe.ui.form.on("Quotation", {
+    party_name: function(frm) {
+        setTimeout(function() {
+            if (!frm.doc.tax_category){
+                frappe.call({
+                    method: "csf_tz.custom_api.get_tax_category",
+                    args: {
+                        doc_type: frm.doc.doctype,
+                        company: frm.doc.company,
+                    },
+                    callback: function(r) {
+                        if(!r.exc) {
+                            frm.set_value("tax_category", r.message);
+                            frm.trigger("tax_category");
+                        }
+                    }
+                });           
+        }
+          }, 1000);   
+    },
+});

--- a/csf_tz/csf_tz/sales_invoice.js
+++ b/csf_tz/csf_tz/sales_invoice.js
@@ -21,6 +21,25 @@ frappe.ui.form.on("Sales Invoice", {
         }
         // frm.trigger("update_stock");
     },  
+    customer: function(frm) {
+        setTimeout(function() {
+            if (!frm.doc.tax_category){
+                frappe.call({
+                    method: "csf_tz.custom_api.get_tax_category",
+                    args: {
+                        doc_type: frm.doc.doctype,
+                        company: frm.doc.company,
+                    },
+                    callback: function(r) {
+                        if(!r.exc) {
+                            frm.set_value("tax_category", r.message);
+                            frm.trigger("tax_category");
+                        }
+                    }
+                });           
+        }
+          }, 1000);   
+    },
     // update_stock: (frm) => {
     //     const warehouse_field = frappe.meta.get_docfield("Sales Invoice Item", "warehouse", frm.doc.name);
     //     const item_field = frappe.meta.get_docfield("Sales Invoice Item", "item_code", frm.doc.name);

--- a/csf_tz/csf_tz/sales_order.js
+++ b/csf_tz/csf_tz/sales_order.js
@@ -1,3 +1,25 @@
+frappe.ui.form.on("Sales Order", {
+    customer: function(frm) {
+        setTimeout(function() {
+            if (!frm.doc.tax_category){
+                frappe.call({
+                    method: "csf_tz.custom_api.get_tax_category",
+                    args: {
+                        doc_type: frm.doc.doctype,
+                        company: frm.doc.company,
+                    },
+                    callback: function(r) {
+                        if(!r.exc) {
+                            frm.set_value("tax_category", r.message);
+                            frm.trigger("tax_category");
+                        }
+                    }
+                });           
+        }
+          }, 1000);   
+    },
+});
+
 frappe.ui.keys.add_shortcut({
     shortcut: 'ctrl+q',
     action: () => { 

--- a/csf_tz/custom_api.py
+++ b/csf_tz/custom_api.py
@@ -1047,6 +1047,9 @@ def make_withholding_tax_gl_entries(doc, method):
 
 @frappe.whitelist()
 def get_tax_category(doc_type, company):
+    fetch_default_tax_category = frappe.db.get_value('CSF TZ Settings', None, 'fetch_default_tax_category') or 0
+    if int(fetch_default_tax_category) != 1:
+        return ""
     sales_list_types = ["Sales Order","Sales Invoice","Delivery Note","Quotation"]
     Puchase_list_types = ["Purchase Order","Purchase Invoice","Purchase Receipt"]
     tax_category = []
@@ -1069,15 +1072,3 @@ def get_tax_category(doc_type, company):
             fields = ["name","tax_category"]
         )
     return tax_category[0]["tax_category"] if len(tax_category) > 0 else [""]
-
-
-# def set_tax_category(doc, method):
-#     if doc.tax_category:
-#         return
-#     tax_category = get_tax_category(doc.doctype, doc.company)
-#     # print_out(tax_category)
-#     doc.tax_category = tax_category
-#     # for item in doc.items:
-#     # #     item.item_tax_template = ""
-#     # doc.run_method("set_missing_values")
-#     # doc.run_method("calculate_taxes_and_totals")

--- a/csf_tz/custom_api.py
+++ b/csf_tz/custom_api.py
@@ -1043,3 +1043,41 @@ def make_withholding_tax_gl_entries(doc, method):
         jv_url = frappe.utils.get_url_to_form(jv_doc.doctype, jv_doc.name)
         si_msgprint = "Journal Entry Created for Withholding Tax <a href='{0}'>{1}</a>".format(jv_url,jv_doc.name)
         frappe.msgprint(_(si_msgprint))
+
+
+@frappe.whitelist()
+def get_tax_category(doc_type, company):
+    sales_list_types = ["Sales Order","Sales Invoice","Delivery Note","Quotation"]
+    Puchase_list_types = ["Purchase Order","Purchase Invoice","Purchase Receipt"]
+    tax_category = []
+    if doc_type in sales_list_types:
+        tax_category = frappe.get_all(
+            "Sales Taxes and Charges Template",
+            filters = [
+                ["Sales Taxes and Charges Template","company","=",company],
+                ["Sales Taxes and Charges Template","is_default","=",1]
+            ],
+            fields = ["name","tax_category"]
+        )
+    elif doc_type in Puchase_list_types:
+        tax_category = frappe.get_all(
+            "Purchase Taxes and Charges Template",
+            filters = [
+                ["Purchase Taxes and Charges Template","company","=",company],
+                ["Purchase Taxes and Charges Template","is_default","=",1]
+            ],
+            fields = ["name","tax_category"]
+        )
+    return tax_category[0]["tax_category"] if len(tax_category) > 0 else [""]
+
+
+# def set_tax_category(doc, method):
+#     if doc.tax_category:
+#         return
+#     tax_category = get_tax_category(doc.doctype, doc.company)
+#     # print_out(tax_category)
+#     doc.tax_category = tax_category
+#     # for item in doc.items:
+#     # #     item.item_tax_template = ""
+#     # doc.run_method("set_missing_values")
+#     # doc.run_method("calculate_taxes_and_totals")

--- a/csf_tz/hooks.py
+++ b/csf_tz/hooks.py
@@ -131,6 +131,10 @@ doctype_js = {
 	"Warehouse" : "csf_tz/warehouse.js",
 	"Company": "csf_tz/company.js",
 	"Stock Reconciliation": "csf_tz/stock_reconciliation.js",
+	"Purchase Invoice": "csf_tz/purchase_invoice.js",
+	"Quotation": "csf_tz/quotation.js",
+	"Purchase Receipt": "csf_tz/purchase_receipt.js",
+	"Purchase Order": "csf_tz/purchase_order.js",
 }
 # doctype_list_js = {"doctype" : "public/js/doctype_list.js"}
 # doctype_tree_js = {"doctype" : "public/js/doctype_tree.js"}


### PR DESCRIPTION
- [ ]  Fetch Tax Category based on default Sales Tax and Charges Template
- [ ]  Fetch Tax Category based on default Purchase Tax and Charges Template
- [ ]  CSF TZ to have a checkbox to fetch or not to "Fetch Tax Category from Default Tax Templates"
- [ ]  Affected doctypes indicated in DocTypes
- [ ]  Only Fetch if the Tax Category is not already selected in the DocType.
If **Quotation**, **Sales Order**, **Sales Invoice**, **Delivery Note**, then use Sales Taxes and Charges Template (tax category of default document)
If **Purchase Receipt,** **Purchase Order**, **Purchase Invoice,** then use Purchase Taxes and Charges Template (tax category of default document)