### PR TITLE
feat: wtax should be against accounts payable or accounts receivable type account

### DIFF
--- a/csf_tz/csf_tz/company.js
+++ b/csf_tz/csf_tz/company.js
@@ -5,7 +5,7 @@ frappe.ui.form.on("Company", {
 			return {
 				"filters": {
                     "company": frm.doc.name,
-                    "account_type": "Tax",
+                    "account_type": "Payable",
 				}
 			};
 		});
@@ -13,7 +13,7 @@ frappe.ui.form.on("Company", {
 			return {
 				"filters": {
                     "company": frm.doc.name,
-                    "account_type": "Tax",
+                    "account_type": "Receivable",
 				}
 			};
 		});


### PR DESCRIPTION
- [ ]  Check the accounts payable and accounts receivable type for WTax setup in "Company" doctype and ask for confirmation if they really want to have accounts payable and receivable type NOT set.
- [ ]  If the account type is 'Receivable' only then create the journals by using the party and party name, so that the debt and credit is not removed but transferred from one account to another account.
- [ ]  If the account type is not 'Receivable' then do not create the journal with party type and party name, just normal journal as it is currently done.