### PR TITLE
feat: Program Enrollment

### DIFF
--- a/csf_tz/csf_tz/program_enrollment.js
+++ b/csf_tz/csf_tz/program_enrollment.js
@@ -1,0 +1,34 @@
+frappe.ui.form.on("Program Enrollment", {
+    program: function (frm) {
+        frm.set_value("fees", "");
+        frm.events.get_courses(frm);
+        if (frm.doc.program) {
+            frappe.call({
+                method: "csf_tz.csftz_hooks.program_enrollment.get_fee_schedule",
+                args: {
+                    "program": frm.doc.program,
+                    "student_category": frm.doc.student_category,
+                    "academic_year": frm.doc.academic_year,
+                    "academic_term": frm.doc.academic_term
+                },
+                async: false,
+                callback: function (r) {
+                    if (r.message) {
+                        frm.set_value("fees", r.message);
+                        frm.events.get_courses(frm);
+                    }
+                }
+            });
+        }
+    },
+
+    student_category: function () {
+        frappe.ui.form.trigger("program");
+    },
+    
+    validate: function (frm) {
+        if (( !frm.doc.fees || !frm.doc.fees.length) && frm.doc.student_category) {
+            frm.trigger("program");
+        }
+    }
+});

--- a/csf_tz/csftz_hooks/program_enrollment.py
+++ b/csf_tz/csftz_hooks/program_enrollment.py
@@ -1,13 +1,53 @@
 from __future__ import unicode_literals
 import frappe
+from frappe import _
 from erpnext.education.doctype.program_enrollment.program_enrollment import ProgramEnrollment
+# from csf_tz import console
+
 
 def create_course_enrollments(self):
     student = frappe.get_doc("Student", self.student)
     program = frappe.get_doc("Program", self.program)
     course_list = [course.course for course in program.courses]
     for course_name in course_list:
-        student.enroll_in_course(course_name=course_name, program_enrollment=self.name)
+        student.enroll_in_course(
+            course_name=course_name, program_enrollment=self.name)
+
 
 def create_course_enrollments_override(doc, method):
     ProgramEnrollment.create_course_enrollments = create_course_enrollments
+
+
+@frappe.whitelist()
+def get_fee_schedule(program, academic_year, academic_term=None, student_category=None):
+    """Returns Fee Schedule.
+
+    :param program: Program.
+    :param student_category: Student Category
+    :param academic_year
+    :param academic_term
+    """
+    fs = frappe.get_list("Program Fee", fields=["academic_term", "fee_structure", "due_date", "amount"],
+                         filters={"parent": program, "student_category": student_category}, order_by="idx")
+
+    fees_list = []
+    for i in fs:
+        fs_academic_year = frappe.get_value(
+            "Fee Structure", i["fee_structure"], "academic_year") or ""
+        fs_academic_term = "False"
+        if academic_term:
+            fs_academic_term = frappe.get_value(
+                "Fee Structure", i["fee_structure"], "academic_term") or ""
+        if fs_academic_term != "False":
+            if fs_academic_term == academic_term and fs_academic_year == academic_year:
+                fees_list.append(i)
+        else:
+            if fs_academic_year == academic_year:
+                fees_list.append(i)
+
+    return fees_list
+
+
+def validate_submit_program_enrollment(doc, method):
+    if not doc.student_category:
+        frappe.throw(_("Please set Student Category"))

--- a/csf_tz/hooks.py
+++ b/csf_tz/hooks.py
@@ -173,6 +173,7 @@ doctype_js = {
 	"Purchase Receipt": "csf_tz/purchase_receipt.js",
 	"Purchase Order": "csf_tz/purchase_order.js",
 	"Student Applicant": "csf_tz/student_applicant.js",
+	"Program Enrollment": "csf_tz/program_enrollment.js",
 }
 # doctype_list_js = {"doctype" : "public/js/doctype_list.js"}
 # doctype_tree_js = {"doctype" : "public/js/doctype_tree.js"}
@@ -265,6 +266,7 @@ doc_events = {
 		"onload":"csf_tz.csftz_hooks.program_enrollment.create_course_enrollments_override",
 		"refresh":"csf_tz.csftz_hooks.program_enrollment.create_course_enrollments_override",
 		"reload":"csf_tz.csftz_hooks.program_enrollment.create_course_enrollments_override",
+		"before_submit":"csf_tz.csftz_hooks.program_enrollment.validate_submit_program_enrollment",
 	},
 	"*": {
 		"validate"                      :  ["csf_tz.csf_tz.doctype.visibility.visibility.run_visibility"],


### PR DESCRIPTION
- [ ]  Program Enrolment uses Fee Structure to pull up the fees. It pulls up all fee categories. Need to only load fees related to the Academic Year and Academic Term
- [ ]  Do not allow submit if the Student Category is not entered. It is not mandatory to allow saving the record but should not be allowed to be submitted. (Mandatory on submission)
- [ ]  Currently loading of fees after change of student category is a whitelisted python called from js function. Need to put it in validate method only if the student_category is filled and fees records are empty. If fees records are manually. This function is the same that we make the new whitelisted function in the above requirement