### PR TITLE
fix: Calculation for pending deliveries uses SI delivered_qty that is not updated in most scenarios

### DIFF
--- a/csf_tz/custom_api.py
+++ b/csf_tz/custom_api.py
@@ -578,8 +578,8 @@ def delete_doc(doctype,docname):
 
 def get_pending_delivery_item_count(item_code, company, warehouse):
     query = """ SELECT SUM(SIT.delivered_qty) as delivered_cont ,SUM(SIT.stock_qty) as sold_cont
-            FROM `tabSales Invoice` AS SI 
-            INNER JOIN `tabSales Invoice Item` AS SIT ON SIT.parent = SI.name 
+            FROM `tabSales Order` AS SI 
+            INNER JOIN `tabSales Order Item` AS SIT ON SIT.parent = SI.name 
             WHERE 
                 SIT.item_code = '%s' 
                 AND SIT.parent = SI.name 


### PR DESCRIPTION
# Description:

In custom_api.py

```jsx
def get_pending_delivery_item_count(item_code, company, warehouse):
    query = """ SELECT SUM(SIT.delivered_qty) as delivered_cont ,SUM(SIT.stock_qty) as sold_cont
            FROM `tabSales Invoice` AS SI 
            INNER JOIN `tabSales Invoice Item` AS SIT ON SIT.parent = SI.name 
            WHERE 
                SIT.item_code = '%s' 
                AND SIT.parent = SI.name 
                AND SI.docstatus= 1 
                AND SI.update_stock != 1 
                AND SI.company = '%s' 
                AND SIT.warehouse = '%s' 
            """ %(item_code,company,warehouse)

    counts = frappe.db.sql(query,as_dict=True)
    if len(counts) > 0:
        if not counts[0]["sold_cont"]:
            counts[0]["sold_cont"] = 0
        if not counts[0]["delivered_cont"]:
            counts[0]["delivered_cont"] = 0
        return counts[0]["sold_cont"] - counts[0]["delivered_cont"]
    else:
        return 0
```

---

- [ ]  Use Sales Order instead of Sales Invoice to find out the pending qty and use delivered_qty from Sales Order