### PR TITLE
feat: `_max_writes_allowed` site config; provision for monkey patches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 tags
 csf_tz/docs/current
 node_modules
+.vscode/

--- a/csf_tz/__init__.py
+++ b/csf_tz/__init__.py
@@ -1,19 +1,49 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+import os
+import importlib
+
 import frappe
 
-__version__ = '2.0.0'
+__version__ = "2.0.0"
+patches_loaded = False
+
 
 def console(*data):
-    frappe.publish_realtime('out_to_console', data, user=frappe.session.user)
+    frappe.publish_realtime("out_to_console", data, user=frappe.session.user)
+
+
+def load_monkey_patches():
+    global patches_loaded
+
+    if (
+        patches_loaded
+        or not getattr(frappe, "conf", None)
+        or not "csf_tz" in frappe.get_installed_apps()
+    ):
+        return
+
+    for module_name in os.listdir(frappe.get_app_path("csf_tz", "monkey_patches")):
+        if not module_name.endswith(".py") or module_name == "__init__.py":
+            continue
+
+        importlib.import_module("csf_tz.monkey_patches." + module_name[:-3])
+
+    patches_loaded = True
+
+
 
 connect = frappe.connect
 
+
 def custom_connect(*args, **kwargs):
     out = connect(*args, **kwargs)
+
     if frappe.conf.auto_commit_on_many_writes:
         frappe.db.auto_commit_on_many_writes = 1
 
+    load_monkey_patches()
     return out
+
 
 frappe.connect = custom_connect

--- a/csf_tz/monkey_patches/db_transaction_writes.py
+++ b/csf_tz/monkey_patches/db_transaction_writes.py
@@ -1,0 +1,31 @@
+import frappe
+from frappe import _
+from frappe.database.database import Database
+
+
+def check_transaction_status(self, query, *args, **kwargs):
+    if (
+        self.transaction_writes
+        and query
+        and query.strip().split()[0].lower()
+        in ("start", "alter", "drop", "create", "begin", "truncate")
+    ):
+        raise Exception("This statement can cause implicit commit")
+
+    if query and query.strip().lower() in ("commit", "rollback"):
+        self.transaction_writes = 0
+
+    if query[:6].lower() not in ("update", "insert", "delete"):
+        return
+
+    self.transaction_writes += 1
+    if self.transaction_writes > (frappe.conf._max_writes_allowed or 200000):
+        if self.auto_commit_on_many_writes:
+            self.commit()
+        else:
+            frappe.throw(
+                _("Too many writes in one request. Please send smaller requests"),
+                frappe.ValidationError,
+            )
+
+Database.check_transaction_status = check_transaction_status

--- a/csf_tz/monkey_patches/db_transaction_writes.py
+++ b/csf_tz/monkey_patches/db_transaction_writes.py
@@ -1,5 +1,6 @@
 import frappe
 from frappe import _
+from frappe.utils import cint
 from frappe.database.database import Database
 
 
@@ -19,7 +20,7 @@ def check_transaction_status(self, query, *args, **kwargs):
         return
 
     self.transaction_writes += 1
-    if self.transaction_writes > (frappe.conf._max_writes_allowed or 200000):
+    if self.transaction_writes > (cint(frappe.conf._max_writes_allowed) or 200000):
         if self.auto_commit_on_many_writes:
             self.commit()
         else:


### PR DESCRIPTION
- New monkey patches can be added by simple placing a module in the `monkey_patches` package.
- `_max_writes_allowed` can be set in `site_config.json` to an integer.